### PR TITLE
Fixes #67 - Clicks outside network sidebar

### DIFF
--- a/packages/apps/src/Menu/ChainInfo.tsx
+++ b/packages/apps/src/Menu/ChainInfo.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2025 @polkadot/apps authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { ChainImg, Icon, styled } from '@polkadot/react-components';
 import { useIpfs, useToggle } from '@polkadot/react-hooks';
@@ -17,9 +17,29 @@ function ChainInfo ({ className }: Props): React.ReactElement<Props> {
   const { ipnsChain } = useIpfs();
   const [isEndpointsVisible, toggleEndpoints] = useToggle();
   const canToggle = !ipnsChain;
+  const divRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (divRef.current && !divRef.current.contains(event.target as Node)) {
+        toggleEndpoints();
+      }
+    };
+
+    if (isEndpointsVisible) {
+      document.addEventListener('click', handleClick);
+    } else {
+      document.removeEventListener('click', handleClick);
+    }
+
+    // Cleanup function to remove the event listener
+    return () => {
+      document.removeEventListener('click', handleClick);
+    };
+  }, [isEndpointsVisible, toggleEndpoints]);
 
   return (
-    <StyledDiv className={`${className}`}>
+    <StyledDiv ref={divRef} className={`${className}`}>
       <div
         className={`apps--SideBar-logo-inner${canToggle ? ' isClickable' : ''} `}
         onClick={toggleEndpoints}

--- a/packages/apps/src/Menu/ChainInfo.tsx
+++ b/packages/apps/src/Menu/ChainInfo.tsx
@@ -39,7 +39,10 @@ function ChainInfo ({ className }: Props): React.ReactElement<Props> {
   }, [isEndpointsVisible, toggleEndpoints]);
 
   return (
-    <StyledDiv ref={divRef} className={`${className}`}>
+    <StyledDiv
+      className={`${className}`}
+      ref={divRef}
+    >
       <div
         className={`apps--SideBar-logo-inner${canToggle ? ' isClickable' : ''} `}
         onClick={toggleEndpoints}

--- a/packages/apps/src/Menu/ChainInfo.tsx
+++ b/packages/apps/src/Menu/ChainInfo.tsx
@@ -20,21 +20,32 @@ function ChainInfo ({ className }: Props): React.ReactElement<Props> {
   const divRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    // Close Network selection layer on click outside.
     const handleClick = (event: MouseEvent) => {
       if (divRef.current && !divRef.current.contains(event.target as Node)) {
         toggleEndpoints();
       }
     };
 
+    // Close Network selection layer on ESC key.
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        toggleEndpoints();
+      }
+    };
+
     if (isEndpointsVisible) {
       document.addEventListener('click', handleClick);
+      document.addEventListener('keydown', handleKeyDown);
     } else {
       document.removeEventListener('click', handleClick);
+      document.removeEventListener('keydown', handleKeyDown);
     }
 
-    // Cleanup function to remove the event listener
+    // Cleanup function to remove the event listeners.
     return () => {
       document.removeEventListener('click', handleClick);
+      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [isEndpointsVisible, toggleEndpoints]);
 


### PR DESCRIPTION
Add click (will work for touch events as well) event listener is the network selection is open.

Logic applied within event:
**If click inside network selection `do nothing` else `close layer`.**