### PR TITLE
fix: remove some extrinsics of subnet

### DIFF
--- a/packages/react-components/src/InputExtrinsic/SelectMethod.tsx
+++ b/packages/react-components/src/InputExtrinsic/SelectMethod.tsx
@@ -40,7 +40,7 @@ function SelectMethod ({ api, methodType, onChange, options, setBtnDisable, valu
   const methodMappings: Record<string, Record<string, MethodDetails>> = {
     Bittensor: {
       Subnet: {
-        adminUtils: ['sudoSetMinBurn', 'sudoSetMaxBurn', 'sudoSetNetworkRegistrationAllowed', 'sudoSetAdjustmentAlpha', 'sudoSetImmunityPeriod', 'sudoSetKappa', 'sudoSetTempo', 'sudoSetMaxRegistrationsPerBlock', 'sudoSetTargetRegistrationsPerInterval'],
+        adminUtils: ['sudoSetMaxBurn', 'sudoSetNetworkRegistrationAllowed', 'sudoSetAdjustmentAlpha', 'sudoSetImmunityPeriod', 'sudoSetKappa'],
         subtensorModule: ['registerNetwork', 'dissolveNetwork', 'scheduleDissolveNetwork', 'setSubnetIdentity']
       },
       User: {


### PR DESCRIPTION
permissions required for several extrinsics have changed
as a result, owners can no longer call some extrinsics that they previously could